### PR TITLE
Skip delete commit when files are empty

### DIFF
--- a/src/git-strip-merge.js
+++ b/src/git-strip-merge.js
@@ -56,9 +56,12 @@ module.exports = async function gitStripMerge(
     cwd,
   });
 
-  await git.rm(files);
-  // await git.raw(['rm', '-rf', ...excludePaths]);
-  await git.commit(deleteCommitMessage);
+  // Running git rm without any paths would fail
+  if (files.length > 0) {
+    await git.rm(files);
+    await git.commit(deleteCommitMessage);
+  }
+
   const newSha = await git.revparse('HEAD');
   await git.checkout(original);
   await git.merge(['-m', mergeCommitMessage, newSha, '--no-ff']);


### PR DESCRIPTION
When no files are excluded by the patterns, it would run `git rm` without any paths what would result in an error.